### PR TITLE
Add linting workflow for main branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,23 @@
+name: Lint
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  # Required: allow read access to the content for analysis.
+  contents: read
+  # Optional: allow read access to pull request. Use with `only-new-issues` option.
+  pull-requests: read
+  # Optional: allow write access to checks to allow the action to annotate code in the PR.
+  checks: write
+
+jobs:
+  test:
+    runs-on:
+      group: default
+    steps:
+      - name: print
+        run: echo "This is a placeholder for linting steps. Please implement linting commands here."


### PR DESCRIPTION
This workflow triggers on pushes and pull requests to the main branch, allowing for linting steps to be implemented.